### PR TITLE
支持 dockerfile + docker-compose 方式启动

### DIFF
--- a/hbase/Dockerfile
+++ b/hbase/Dockerfile
@@ -89,7 +89,7 @@ EXPOSE 2181 8080 8085 9090 9095 16000 16010 16020 16030
 ENTRYPOINT ["/entrypoint.sh"]
 
 # cd hbase 
-# docker build -t hbase:2.3.3 .
-# docker tag hbase:2.3.3 geekyouth/hbase:2.3.3
-# docker push geekyouth/hbase:2.3.3
-# docker rmi hbase:2.3.3
+# docker build -t hbase:2.3.3.1 .
+# docker tag hbase:2.3.3.1 geekyouth/hbase:2.3.3.1
+# docker push geekyouth/hbase:2.3.3.1
+# docker rmi hbase:2.3.3.1

--- a/hbase/README.MD
+++ b/hbase/README.MD
@@ -1,0 +1,83 @@
+# 1、启动 hbase 的方式（二选一）：
+
+## 1.1、docker image 方式
+此方式运行时，不要修改端口号映射规则，并且 Java/scala 项目需要如下配置，来映射 hostname 和 ip 关系，可以省去修改 hosts 文件：  
+
+```xml
+<dependency>
+   <groupId>io.leopard</groupId>
+    <artifactId>javahost</artifactId>
+    <version>0.9.6</version>
+</dependency>
+```
+
+```java
+import io.leopard.javahost.JavaHost
+
+// 代码放在靠前的位置执行
+JavaHost.updateVirtualDns("hbase", "127.0.0.1");
+```
+
+```shell
+docker run -d --name hbase --hostname hbase -p 2181:2181 -p 8080:8080 -p 8085:8085 -p 9090:9090 -p 9095:9095 -p 16000:16000 -p 16010:16010 -p 16020:16020 -p 16030:16030 geekyouth/hbase:2.3.3.1
+```
+
+## 1.2、docker-compose 方式
+
+hbase-compose.yaml
+```yaml
+version: "3.3"
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:5.5.0
+    hostname: zookeeper
+    container_name: zookeeper
+    ports:
+      - 2181:2181
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  hbase:
+    image: geekyouth/hbase:2.3.3.1
+    hostname: hbase
+    container_name: hbase
+    depends_on:
+      - zookeeper
+    ports:
+      - 8080:8080
+      - 8085:8085
+      - 9090:9090
+      - 9095:9095
+      - 16000:16000
+      - 16010:16010
+      - 16020:16020
+      - 16030:16030
+    environment:
+      ZK_SERVER: zookeeper:2181
+```
+启动方式：
+```shell
+# 后台启动
+docker-compose -f ./hbase-compose.yaml up -d
+# 停止并删除 container
+docker-compose -f ./hbase-compose.yaml kill
+docker-compose -f ./hbase-compose.yaml rm -f
+```
+
+同样也需要在项目中配置如下：
+```xml
+<dependency>
+   <groupId>io.leopard</groupId>
+    <artifactId>javahost</artifactId>
+    <version>0.9.6</version>
+</dependency>
+```
+
+```java
+import io.leopard.javahost.JavaHost
+// 代码放在靠前的位置执行
+JavaHost.updateVirtualDns("hbase", "127.0.0.1");
+JavaHost.updateVirtualDns("zookeeper", "127.0.0.1");
+```
+

--- a/hbase/conf/hbase-site.xml
+++ b/hbase/conf/hbase-site.xml
@@ -16,6 +16,6 @@
   </property>
   <property>
     <name>hbase.zookeeper.quorum</name>
-    <value>zookeeper:2181</value>
+    <value>localhost:2181</value>
   </property>
 </configuration>

--- a/hbase/entrypoint.sh
+++ b/hbase/entrypoint.sh
@@ -20,6 +20,7 @@ set -euo pipefail
 
 export HBASE_HOME="/hbase"
 export JAVA_HOME="${JAVA_HOME:-/usr}"
+export ZK_SERVER="${ZK_SERVER:-localhost:2181}"
 
 echo "================================================================================"
 echo "                              HBase Docker Container"
@@ -129,8 +130,12 @@ if [ -n "$*" ]; then
         echo "usage:  must specify one of: master, regionserver, thrift, rest, shell, bash"
     fi
 else
-    sed -i 's/zookeeper:2181/localhost:2181/' "$HBASE_HOME/conf/hbase-site.xml"
-    start_zookeeper
+#    sed -e "s|localhost:2181|$ZK_SERVER|" $HBASE_HOME/conf/hbase-site.xml
+    sed -i "s/localhost:2181/$ZK_SERVER/" $HBASE_HOME/conf/hbase-site.xml
+    if [ "$ZK_SERVER" = localhost:2181 ] || [ "$ZK_SERVER" = 127.0.0.1:2181 ]; then
+      start_zookeeper
+    fi
+
     start_master
     start_regionserver
     start_stargate


### PR DESCRIPTION
# 1、启动 hbase 的方式（二选一）：

## 1.1、docker image 方式
此方式运行时，不要修改端口号映射规则，并且 Java/scala 项目需要如下配置，来映射 hostname 和 ip 关系，可以省去修改 hosts 文件：  

```xml
<dependency>
   <groupId>io.leopard</groupId>
    <artifactId>javahost</artifactId>
    <version>0.9.6</version>
</dependency>
```

```java
import io.leopard.javahost.JavaHost

// 代码放在靠前的位置执行
JavaHost.updateVirtualDns("hbase", "127.0.0.1");
```

```shell
docker run -d --name hbase --hostname hbase -p 2181:2181 -p 8080:8080 -p 8085:8085 -p 9090:9090 -p 9095:9095 -p 16000:16000 -p 16010:16010 -p 16020:16020 -p 16030:16030 geekyouth/hbase:2.3.3.1
```

## 1.2、docker-compose 方式

hbase-compose.yaml
```yaml
version: "3.3"
services:
  zookeeper:
    image: confluentinc/cp-zookeeper:5.5.0
    hostname: zookeeper
    container_name: zookeeper
    ports:
      - 2181:2181
    environment:
      ZOOKEEPER_CLIENT_PORT: 2181
      ZOOKEEPER_TICK_TIME: 2000

  hbase:
    image: geekyouth/hbase:2.3.3.1
    hostname: hbase
    container_name: hbase
    depends_on:
      - zookeeper
    ports:
      - 8080:8080
      - 8085:8085
      - 9090:9090
      - 9095:9095
      - 16000:16000
      - 16010:16010
      - 16020:16020
      - 16030:16030
    environment:
      ZK_SERVER: zookeeper:2181
```
启动方式：
```shell
# 后台启动
docker-compose -f ./hbase-compose.yaml up -d
# 停止并删除 container
docker-compose -f ./hbase-compose.yaml kill
docker-compose -f ./hbase-compose.yaml rm -f
```

同样也需要在项目中配置如下：
```xml
<dependency>
   <groupId>io.leopard</groupId>
    <artifactId>javahost</artifactId>
    <version>0.9.6</version>
</dependency>
```

```java
import io.leopard.javahost.JavaHost
// 代码放在靠前的位置执行
JavaHost.updateVirtualDns("hbase", "127.0.0.1");
JavaHost.updateVirtualDns("zookeeper", "127.0.0.1");
```

